### PR TITLE
Fix: Enforce maximum move limit in game interactions

### DIFF
--- a/js/board.js
+++ b/js/board.js
@@ -119,7 +119,7 @@ define(["js/properties", "js/sound", "js/squareImages", "js/info"], (properties,
     };
 
     Board.prototype.clicked = event => {
-        if (level.filledSquares() < level.squaresToFill) {
+        if (level.filledSquares() < level.squaresToFill && info.movementTotal() < level.maxMovementsAchievement) {
             if (event.target.className.startsWith("squareImage")) {
                 if (level.pinSelected) {
                     level.board.pinSquare(event.target.id);
@@ -143,7 +143,7 @@ define(["js/properties", "js/sound", "js/squareImages", "js/info"], (properties,
     }   
 
     Board.prototype.mouseover = event => {    
-        if (level.filledSquares() < level.squaresToFill) {  
+        if (level.filledSquares() < level.squaresToFill && info.movementTotal() < level.maxMovementsAchievement) {
             if (event.target.className.startsWith("squareImage")) { 
                 const squarePosition = squareImages.getPosition(event.target.id); 
                 let mouseOveredSquare = level.board.squares[squarePosition[0]][squarePosition[1]];  
@@ -156,7 +156,7 @@ define(["js/properties", "js/sound", "js/squareImages", "js/info"], (properties,
     };  
     
     Board.prototype.mouseout = event => { 
-        if (level.filledSquares() < level.squaresToFill) {  
+        if (level.filledSquares() < level.squaresToFill && info.movementTotal() < level.maxMovementsAchievement) {
             if (event.target.className.startsWith("squareImage")) { 
                 const squarePosition = squareImages.getPosition(event.target.id); 
                 let mouseOveredSquare = level.board.squares[squarePosition[0]][squarePosition[1]];  


### PR DESCRIPTION
## Summary

This PR fixes the issue where the game was not properly enforcing the maximum move limit, allowing players to continue making moves beyond the achievement threshold.

## Changes Made

**File Modified:** `js/board.js`

**Functions Updated:**
1. `Board.prototype.clicked` (Line 122)
2. `Board.prototype.mouseover` (Line 146) 
3. `Board.prototype.mouseout` (Line 159)

**Change Details:**
- **Before:** `if (level.filledSquares() < level.squaresToFill) {`
- **After:** `if (level.filledSquares() < level.squaresToFill && info.movementTotal() < level.maxMovementsAchievement) {`

## What This Fix Does

- ✅ **Prevents clicking/interaction:** When a player reaches the maximum number of moves (`level.maxMovementsAchievement`), they can no longer click on squares to make moves
- ✅ **Prevents hover effects:** The visual feedback (scaling effects) are also disabled once the move limit is reached
- ✅ **Maintains game state:** The game continues to track completion status but prevents further moves beyond the limit

## Technical Implementation

- Leverages the existing `info` module which was already imported in `board.js`
- Uses the `info.movementTotal()` function to get current move count
- Compares against `level.maxMovementsAchievement` for the move limit
- Consistent implementation across all three interaction functions
- No additional dependencies required

## Testing

The fix has been tested to ensure:
- Move limit is properly enforced
- Game interactions are disabled when limit is reached
- Existing functionality remains intact
- No breaking changes introduced

Fixes #1